### PR TITLE
Added Modal.delete component

### DIFF
--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
+import CloseOutlined from '@ant-design/icons/CloseOutlined';
 import Dialog, { ModalFuncProps } from './Modal';
 import ActionButton from './ActionButton';
 import devWarning from '../_util/devWarning';
@@ -72,6 +73,25 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
     </ActionButton>
   );
 
+  const closeIconToRender = (
+    <span className={`${prefixCls}-close-x`}>
+      <CloseOutlined className={`${prefixCls}-close-icon`} />
+    </span>
+  );
+
+  const closeButton = okCancel && (
+    <span className={`${contentPrefixCls}-delete-close-icon`}>
+      <ActionButton
+        actionFn={onCancel}
+        closeModal={close}
+        buttonProps={cancelButtonProps}
+        prefixCls={`${rootPrefixCls}-modal-close`}
+      >
+        {closeIconToRender}
+      </ActionButton>
+    </span>
+  );
+
   return (
     <Dialog
       prefixCls={prefixCls}
@@ -100,6 +120,7 @@ const ConfirmDialog = (props: ConfirmDialogProps) => {
           {props.title === undefined ? null : (
             <span className={`${contentPrefixCls}-title`}>{props.title}</span>
           )}
+          {closeButton}
           <div className={`${contentPrefixCls}-content`}>{props.content}</div>
         </div>
         <div className={`${contentPrefixCls}-btns`}>

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -14,9 +14,7 @@ function getRootPrefixCls() {
   return defaultRootPrefixCls;
 }
 
-export type ModalFunc = (
-  props: ModalFuncProps,
-) => {
+export type ModalFunc = (props: ModalFuncProps) => {
   destroy: () => void;
   update: (newConfig: ModalFuncProps) => void;
 };
@@ -28,6 +26,7 @@ export interface ModalStaticFunctions {
   warn: ModalFunc;
   warning: ModalFunc;
   confirm: ModalFunc;
+  delete: ModalFunc;
 }
 
 export default function confirm(config: ModalFuncProps) {
@@ -142,6 +141,31 @@ export function withConfirm(props: ModalFuncProps): ModalFuncProps {
   return {
     type: 'confirm',
     icon: <ExclamationCircleOutlined />,
+    okCancel: true,
+    ...props,
+  };
+}
+
+export function withDelete(props: ModalFuncProps): ModalFuncProps {
+  // Ok button with as 'danger'
+  if (props.okButtonProps) {
+    props.okButtonProps.danger = true;
+  } else if (props.okButtonProps === undefined) {
+    props.okButtonProps = { danger: true };
+  }
+  // auto focus to 'cancel'
+  if (props.autoFocusButton === undefined) {
+    props.autoFocusButton = 'cancel';
+  }
+  // default title and okText
+  if (props.okText === undefined) {
+    props.okText = 'Delete';
+  }
+  if (props.title === undefined) {
+    props.title = 'Delete';
+  }
+  return {
+    type: 'delete',
     okCancel: true,
     ...props,
   };

--- a/components/modal/demo/basic.md
+++ b/components/modal/demo/basic.md
@@ -11,7 +11,7 @@ title:
 
 ## en-US
 
-Basic modals.
+Basic modal.
 
 ```jsx
 import { Modal, Button } from 'antd';
@@ -22,14 +22,6 @@ class App extends React.Component {
   showModal = () => {
     this.setState({
       visible: true,
-    });
-  };
-
-  delModal = () => {
-    Modal.delete({
-      content: <div>Do you really wanted to delete? This process cannot be undone.</div>,
-      onOk: () => console.log('deleted'),
-      onCancel: () => console.log('not deleted'),
     });
   };
 
@@ -63,14 +55,6 @@ class App extends React.Component {
           <p>Some contents...</p>
           <p>Some contents...</p>
         </Modal>
-        <br />
-        <br />
-        <br />
-        <br />
-        <br />
-        <Button type="primary" onClick={this.delModal}>
-          Delete Modal
-        </Button>
       </>
     );
   }

--- a/components/modal/demo/basic.md
+++ b/components/modal/demo/basic.md
@@ -11,7 +11,7 @@ title:
 
 ## en-US
 
-Basic modal.
+Basic modals.
 
 ```jsx
 import { Modal, Button } from 'antd';
@@ -22,6 +22,12 @@ class App extends React.Component {
   showModal = () => {
     this.setState({
       visible: true,
+    });
+  };
+
+  delModal = () => {
+    Modal.delete({
+      content: <p>Do you really wanted to delete? This process cannot be undone.</p>,
     });
   };
 
@@ -55,6 +61,14 @@ class App extends React.Component {
           <p>Some contents...</p>
           <p>Some contents...</p>
         </Modal>
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <Button type="primary" onClick={this.delModal}>
+          Delete Modal
+        </Button>
       </>
     );
   }

--- a/components/modal/demo/basic.md
+++ b/components/modal/demo/basic.md
@@ -27,7 +27,7 @@ class App extends React.Component {
 
   delModal = () => {
     Modal.delete({
-      content: <p>Do you really wanted to delete? This process cannot be undone.</p>,
+      content: <div>Do you really wanted to delete? This process cannot be undone.</div>,
     });
   };
 

--- a/components/modal/demo/basic.md
+++ b/components/modal/demo/basic.md
@@ -28,6 +28,8 @@ class App extends React.Component {
   delModal = () => {
     Modal.delete({
       content: <div>Do you really wanted to delete? This process cannot be undone.</div>,
+      onOk: () => console.log('deleted'),
+      onCancel: () => console.log('not deleted'),
     });
   };
 

--- a/components/modal/demo/info.md
+++ b/components/modal/demo/info.md
@@ -41,6 +41,13 @@ function error() {
     content: 'some messages...some messages...',
   });
 }
+function deleteWarn() {
+  Modal.delete({
+    content: 'Do you really wanted to delete? This process cannot be undone',
+    onOk: () => console.log('deleted'),
+    onCancel: () => console.log('not deleted'),
+  });
+}
 
 function warning() {
   Modal.warning({
@@ -55,6 +62,7 @@ ReactDOM.render(
     <Button onClick={success}>Success</Button>
     <Button onClick={error}>Error</Button>
     <Button onClick={warning}>Warning</Button>
+    <Button onClick={deleteWarn}>Delete</Button>
   </Space>,
   mountNode,
 );

--- a/components/modal/index.tsx
+++ b/components/modal/index.tsx
@@ -1,6 +1,7 @@
 import OriginModal, { ModalFuncProps, destroyFns } from './Modal';
 import confirm, {
   withWarn,
+  withDelete,
   withInfo,
   withSuccess,
   withError,
@@ -38,6 +39,10 @@ Modal.warn = modalWarn;
 
 Modal.confirm = function confirmFn(props: ModalFuncProps) {
   return confirm(withConfirm(props));
+};
+
+Modal.delete = function confirmFn(props: ModalFuncProps) {
+  return confirm(withDelete(props));
 };
 
 Modal.destroyAll = function destroyAllFn() {

--- a/components/modal/style/confirm.less
+++ b/components/modal/style/confirm.less
@@ -80,18 +80,24 @@
 
 .@{confirm-delete-prefix-cls} {
   .@{ant-prefix}-modal-body {
-    padding-bottom: 0px;
+    padding: 0px;
+  }
+  .@{confirm-prefix-cls}-title {
+    padding: 16px 24px;
+  }
+
+  .@{confirm-prefix-cls}-content {
+    margin-top: 0px;
+    padding: 16px 24px;
   }
 
   .@{confirm-prefix-cls}-btns {
     display: flex;
     justify-content: flex-end;
     float: none;
-    // model-body has 32px padding on right and bottom, so, tweak it.
-    margin: 32px -32px 0px -32px;
-    margin-top: 24px;
     padding: 10px 16px;
     background: #f8f8f8;
-    border-top: 1px solid #f0f0f0;
+    border-radius: 0px 0px @border-radius-base @border-radius-base;
+    box-shadow: 0px -1px 0px #e1e1e1;
   }
 }

--- a/components/modal/style/confirm.less
+++ b/components/modal/style/confirm.less
@@ -79,15 +79,27 @@
 }
 
 .@{confirm-delete-prefix-cls} {
-  .@{ant-prefix}-modal-body {
-    padding: 0px;
+  .@{confirm-prefix-cls}-delete-close-icon {
+    .@{ant-prefix}-modal-close {
+      top: -1px; //to align with the title (confirmDialog.tsx)
+      display: block;
+    }
   }
+
+  .@{ant-prefix}-modal-body {
+    padding: 0;
+  }
+
+  .@{ant-prefix}-modal-content {
+    border-radius: 4px;
+  }
+
   .@{confirm-prefix-cls}-title {
     padding: 16px 24px;
   }
 
   .@{confirm-prefix-cls}-content {
-    margin-top: 0px;
+    margin-top: 0;
     padding: 16px 24px;
   }
 
@@ -98,6 +110,6 @@
     padding: 10px 16px;
     background: #f8f8f8;
     border-radius: 0px 0px @border-radius-base @border-radius-base;
-    box-shadow: 0px -1px 0px #e1e1e1;
+    box-shadow: 0 -1px 0 #e1e1e1;
   }
 }

--- a/components/modal/style/confirm.less
+++ b/components/modal/style/confirm.less
@@ -1,6 +1,7 @@
 @import '../../style/mixins/index';
 
 @confirm-prefix-cls: ~'@{ant-prefix}-modal-confirm';
+@confirm-delete-prefix-cls: ~'@{ant-prefix}-modal-confirm-delete';
 
 .@{confirm-prefix-cls} {
   .@{ant-prefix}-modal-header {
@@ -74,5 +75,23 @@
 
   &-success &-body > .@{iconfont-css-prefix} {
     color: @success-color;
+  }
+}
+
+.@{confirm-delete-prefix-cls} {
+  .@{ant-prefix}-modal-body {
+    padding-bottom: 0px;
+  }
+
+  .@{confirm-prefix-cls}-btns {
+    display: flex;
+    justify-content: flex-end;
+    float: none;
+    // model-body has 32px padding on right and bottom, so, tweak it.
+    margin: 32px -32px 0px -32px;
+    margin-top: 24px;
+    padding: 10px 16px;
+    background: #f8f8f8;
+    border-top: 1px solid #f0f0f0;
   }
 }

--- a/components/modal/useModal/index.tsx
+++ b/components/modal/useModal/index.tsx
@@ -9,6 +9,7 @@ import {
   withSuccess,
   withError,
   withWarn,
+  withDelete,
 } from '../confirm';
 
 let uuid = 0;
@@ -58,6 +59,7 @@ export default function useModal(): [Omit<ModalStaticFunctions, 'warn'>, React.R
       error: getConfirmFunc(withError),
       warning: getConfirmFunc(withWarn),
       confirm: getConfirmFunc(withConfirm),
+      delete: getConfirmFunc(withDelete),
     },
     <>{elements}</>,
   ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ym-antd",
-  "version": "4.6.1029",
+  "version": "4.6.1030",
   "description": "An enterprise-class UI design language and React components implementation",
   "title": "Ant Design",
   "keywords": [


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link
https://yellowmessenger.atlassian.net/browse/BLDR-453

### 💡 Background and solution

Previously we were using  `Modal.confirm` component to show a 'delete' prompt. It wasn't good from a UX perspective
![image](https://user-images.githubusercontent.com/46885684/128316025-eab86639-bc9a-4006-b074-61de0ec1da1d.png)

Solution:
- We have implemented a new `Modal.delete` component with extended styles to `Modal.confirmDailog`.
- The focus in delete prompts will be on the 'cancel' button instead of the 'delete' button to avoid accidentally triggering the delete event/action.
![image](https://user-images.githubusercontent.com/46885684/128316666-7f609852-2ec7-4cf5-a226-77f37ef05af8.png)



